### PR TITLE
Fix record duplication(Part1)

### DIFF
--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -17,7 +17,7 @@ class Representative < ApplicationRecord
         end
       end
 
-      rep = Representative.create!({ name: official.name, ocdid: ocdid_temp,
+      rep = Representative.find_or_create_by({ name: official.name, ocdid: ocdid_temp,
           title: title_temp })
       reps.push(rep)
     end

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -1,18 +1,22 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Representative do
   describe 'civic_api_to_representative_params' do
+    let!(:existing_rep) { described_class.create!(name: 'Taylor Swift', ocdid: '123', title: 'Senator') }
+    let(:official) { OpenStruct.new(name: 'Taylor Swift') }
+    let(:office) { OpenStruct.new(name: 'Senator', division_id: '123', official_indices: [0]) }
+    let(:rep_info) { OpenStruct.new(officials: [official], offices: [office]) }
+
     after do
       DatabaseCleaner.clean
     end
 
-    it 'does not add an addition record for an existing representative' do
-	existing_rep = Representative.create!(name: 'Taylor Swift', ocdid: '123', title: 'Senator')
-	rep_info = double('rep_info', officials: [double('official', name: 'Taylor Swift')], offices: [double('office', name: 'Senator', division_id: '123', official_indices: [0])])
-	
-	Representative.civic_api_to_representative_params(rep_info)
-	expect(Representative.count).to eq(1)
+    it 'does not add an additional record for an existing representative' do
+      described_class.civic_api_to_representative_params(rep_info)
+      expect(described_class.count).to eq(1)
+      expect(described_class.last).to eq(existing_rep)
     end
   end
 end
-

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe Representative do
+  describe 'civic_api_to_representative_params' do
+    after do
+      DatabaseCleaner.clean
+    end
+
+    it 'does not add an addition record for an existing representative' do
+	existing_rep = Representative.create!(name: 'Taylor Swift', ocdid: '123', title: 'Senator')
+	rep_info = double('rep_info', officials: [double('official', name: 'Taylor Swift')], offices: [double('office', name: 'Senator', division_id: '123', official_indices: [0])])
+	
+	Representative.civic_api_to_representative_params(rep_info)
+	expect(Representative.count).to eq(1)
+    end
+  end
+end
+


### PR DESCRIPTION
I created a unit test to test if calling civic_api_to_representative_params would add an excessive record in the database. The duplication issue is handled by replacing "create!" with "find_or_create_by" to avoid duplication.